### PR TITLE
[s] fix empty user email from github profile

### DIFF
--- a/app/profile/models.py
+++ b/app/profile/models.py
@@ -89,13 +89,13 @@ class User(db.Model):
         :param oauth_source: From which oauth source the user coming from e.g. github
         :return: User data from Database
         """
-        user = User.query.filter_by(email=user_info['email']).first()
+        user = User.query.filter_by(name=user_info['login']).first()
         if user is None:
             user = User()
-            user.email = user_info['email']
+            user.email = user_info.get('email', None)
             user.secret = os.urandom(24).encode('hex')
             user.name = user_info['login']
-            user.full_name = user_info['name']
+            user.full_name = user_info.get('name', None)
             user.oauth_source = oauth_source
 
             publisher = Publisher(name=user.name)

--- a/tests/profile/test_models.py
+++ b/tests/profile/test_models.py
@@ -122,9 +122,17 @@ class UserTestCase(unittest.TestCase):
         user = User.create_or_update_user_from_callback(user_info)
         self.assertNotEqual('supersecret', user.secret)
 
-    def test_get_userinfo_by_id(self):
+    def test_get_user_info_by_id(self):
         self.assertEqual(User.get_userinfo_by_id(11).name, 'test_user_id')
         self.assertIsNone(User.get_userinfo_by_id(2))
+
+    def test_create_user_should_handle_null_email(self):
+        user_info = dict(login="test_null_email")
+        User.create_or_update_user_from_callback(user_info)
+        user = User.query.filter_by(name='test_null_email').first()
+        self.assertIsNotNone(user)
+        self.assertIsNone(user.email)
+        self.assertIsNone(user.full_name)
 
     def tearDown(self):
         with self.app.app_context():


### PR DESCRIPTION
In github authentication when any user set their email as private
we get email as None. This fix will handle null email from user information.

Added relevant test case.

Ref - #268