### PR TITLE
[xs] add markdown format of the readme

### DIFF
--- a/app/templates/_snippets.html
+++ b/app/templates/_snippets.html
@@ -28,13 +28,13 @@
   {% endfor %}
 {%- endmacro %}
 
-{% macro dataset_show(dataset, jsonDataPackage, dataViews, showDataApi, datapackageUrl) -%}
+{% macro dataset_show(dataset, jsonDataPackage, dataViews, showDataApi, datapackageUrl, readmeShort) -%}
 <div class="dataset show">
   <div class="row">
     <div class="col-md-8">
       <img src="{{dataset.image or 'https://assets.okfn.org/p/data/img/icon-128.png'}}"
         alt="{{dataset.title}}" class="logo" />
-      <div class="description">{{dataset.readme|truncate|markdown}} <a href="#readme">Read more</a></div>
+      <div class="description">{{readmeShort|truncate}} <a href="#readme">Read more</a></div>
 
       <div class="actions">
         <div class="btn-group">

--- a/app/templates/_snippets.html
+++ b/app/templates/_snippets.html
@@ -34,7 +34,7 @@
     <div class="col-md-8">
       <img src="{{dataset.image or 'https://assets.okfn.org/p/data/img/icon-128.png'}}"
         alt="{{dataset.title}}" class="logo" />
-      <div class="description">{{dataset.readme|truncate}} <a href="#readme">Read more</a></div>
+      <div class="description">{{dataset.readme|truncate|markdown}} <a href="#readme">Read more</a></div>
 
       <div class="actions">
         <div class="btn-group">

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -12,7 +12,7 @@
       {{ dataset.title }}
     </h1>
   </div>
-  {{snippets.dataset_show(dataset, jsonDataPackage, dataViews, showDataApi, datapackageUrl)}}
+  {{snippets.dataset_show(dataset, jsonDataPackage, dataViews, showDataApi, datapackageUrl, readmeShort)}}
   <link rel="stylesheet" media="screen" href="{{ s3_cdn }}/static/react/main.css">
   <script type="text/javascript" src="{{ s3_cdn }}/static/react/bundle.js"></script>
 </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ flask-s3==0.3.1
 blinker==1.4
 enum34==1.1.6
 gevent==1.2.1
+BeautifulSoup==3.2.1


### PR DESCRIPTION
The readme section at top of data package view page
was not markdown enabled. This commit will enable the
readme section to be viewed as markdown.

Resolves - #270