### PR TITLE
[L] store jwt in browser cookie.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,7 @@ import boto3
 import sqlalchemy
 from botocore.client import Config
 from flasgger import Swagger
-from flask import Flask, session
+from flask import Flask, session, request, g
 from flask_cors import CORS
 from flaskext.markdown import Markdown
 from flask_gravatar import Gravatar
@@ -19,9 +19,11 @@ from werkzeug.utils import import_string
 from .database import db
 from app.utils import get_s3_cdn_prefix
 from app.auth.controllers import auth_blueprint, bitstore_blueprint
+from app.auth.models import JWT
 from app.package.controllers import package_blueprint
 from app.site.controllers import site_blueprint
 from app.profile.controllers import profile_blueprint
+from app.profile.models import User
 from app.search.controllers import search_blueprint
 
 app_config = {
@@ -108,6 +110,19 @@ def create_app():
 
     @app.context_processor
     def populate_context_variable():
-        return dict(s3_cdn=get_s3_cdn_prefix())
+        return dict(s3_cdn=get_s3_cdn_prefix(),
+                    current_user=g.current_user)
+
+    @app.before_request
+    def get_user_from_cookie():
+        token = request.cookies.get('jwt')
+        g.current_user, g.jwt_exception = None, None
+        if token:
+            try:
+                payload = JWT(app.config['API_KEY']).decode(token)
+                g.current_user = User().get_userinfo_by_id(payload['user'])
+            except Exception as e:
+                app.logger.error(e)
+                g.jwt_exception = e
 
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -116,13 +116,12 @@ def create_app():
     @app.before_request
     def get_user_from_cookie():
         token = request.cookies.get('jwt')
-        g.current_user, g.jwt_exception = None, None
+        g.current_user = None
         if token:
             try:
                 payload = JWT(app.config['API_KEY']).decode(token)
                 g.current_user = User().get_userinfo_by_id(payload['user'])
             except Exception as e:
                 app.logger.error(e)
-                g.jwt_exception = e
 
     return app

--- a/app/auth/controllers.py
+++ b/app/auth/controllers.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from flask import Blueprint, request, render_template, \
-    jsonify, session, make_response
+    jsonify, session, make_response, g
 from flask import current_app as app
 from app.profile.models import User
 from app.auth.models import JWT, FileData
@@ -56,7 +56,8 @@ def callback_handling():
         user = User().create_or_update_user_from_callback(user_info.data)
         jwt_helper = JWT(app.config['API_KEY'], user.id)
         session.pop('github_token', None)
-        resp = make_response(render_template("dashboard.html", user=user,
+        g.current_user = user
+        resp = make_response(render_template("dashboard.html",
                              title='Dashboard'), 200)
         resp.set_cookie('jwt', jwt_helper.encode())
         return resp

--- a/app/auth/controllers.py
+++ b/app/auth/controllers.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from flask import Blueprint, request, render_template, \
-    jsonify, session, url_for
+    jsonify, session, make_response
 from flask import current_app as app
 from app.profile.models import User
 from app.auth.models import JWT, FileData
@@ -56,9 +56,10 @@ def callback_handling():
         user = User().create_or_update_user_from_callback(user_info.data)
         jwt_helper = JWT(app.config['API_KEY'], user.id)
         session.pop('github_token', None)
-        return render_template("dashboard.html", user=user,
-                               title='Dashboard',
-                               encoded_token=jwt_helper.encode()), 200
+        resp = make_response(render_template("dashboard.html", user=user,
+                             title='Dashboard'), 200)
+        resp.set_cookie('jwt', jwt_helper.encode())
+        return resp
     except Exception as e:
         app.logger.error(e)
         return handle_error('GENERIC_ERROR', e.message, 500)

--- a/app/auth/models.py
+++ b/app/auth/models.py
@@ -10,8 +10,9 @@ from app.package.models import BitStore
 
 
 class JWT(object):
+
     def __init__(self, api_key, user_id=None,
-                 expiration_hour=1):
+                 expiration_hour=24):
         self.secret = api_key
         self.user_id = user_id
         self.expiration_hour = expiration_hour

--- a/app/search/controllers.py
+++ b/app/search/controllers.py
@@ -24,8 +24,8 @@ def search_packages():
             - in: query
               name: q
               type: string
-              required: true
-              description: search query string e.g. q=query publisher=pub
+              required: false
+              description: search query string e.g. q=query publisher:pub
         responses:
             500:
                 description: Internal Server Error

--- a/app/search/controllers.py
+++ b/app/search/controllers.py
@@ -24,8 +24,8 @@ def search_packages():
             - in: query
               name: q
               type: string
-              required: false
-              description: search query string e.g. q=query publisher:pub
+              required: true
+              description: search query string e.g. q=query publisher=pub
         responses:
             500:
                 description: Internal Server Error

--- a/app/site/controllers.py
+++ b/app/site/controllers.py
@@ -21,7 +21,8 @@ site_blueprint = Blueprint('site', __name__)
 @site_blueprint.route("/", methods=["GET", "POST"])
 def index():
     """
-    Loads home page
+    Renders index.html if no token found in cookie.
+    If token found in cookie then it renders dashboard.html.
     ---
     tags:
       - site
@@ -31,9 +32,6 @@ def index():
       200:
         description: Successfully loaded home page
     """
-    if g.jwt_exception:
-        return redirect(request.headers['Host'] + '/logout')
-
     if g.current_user:
         return render_template("dashboard.html",
                                title='Dashboard'), 200
@@ -43,7 +41,8 @@ def index():
 @site_blueprint.route("/logout", methods=["GET"])
 def logout():
     """
-    Loads Home page if user already login
+    Sets blank cookie value with expiry time zero
+    and renders logout.html page
     ---
     tags:
       - site
@@ -80,8 +79,6 @@ def datapackage_show(publisher, package):
       200:
         description: Successfully loaded
     """
-    if g.jwt_exception:
-        return redirect(request.headers['Host'] + '/logout')
 
     metadata = json.loads(
         app.test_client(). \
@@ -116,9 +113,6 @@ def datapackage_show(publisher, package):
 
 @site_blueprint.route("/<publisher>", methods=["GET"])
 def publisher_dashboard(publisher):
-    if g.jwt_exception:
-        return redirect(request.headers['Host'] + '/logout')
-
     datapackage_list = DataPackageQuery(query_string="* publisher:{publisher}"
                                         .format(publisher=publisher)).get_data()
     publisher = Publisher.get_publisher_info(publisher)
@@ -130,8 +124,6 @@ def publisher_dashboard(publisher):
 
 @site_blueprint.route("/search", methods=["GET"])
 def search_package():
-    if g.jwt_exception:
-        return redirect(request.headers['Host'] + '/logout')
     q = request.args.get('q')
     if q is None:
         q = ''

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,7 +35,17 @@
           </ul>
 
           <ul class="nav navbar-nav navbar-right">
-            <li><div id="nav-bar-login"></div></li>
+            {% if not user %}
+              <li>
+                <a href="/api/auth/login">Sign In With <span class="fa fa-github fa-lg"></span></a>
+              </li>
+            {% else %}
+              <li>
+                <button class="btn btn-small btn-outline-success p-0">
+                  <a class="nav-link" href="/logout">Logout</a>
+                </button>
+              </li>
+            {% endif %}
           </ul>
         </div>
       </div>
@@ -58,32 +68,6 @@
         ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
-    </script>
-    <script type="text/javascript">
-      var local_jwt = localStorage.getItem('encoded_token');
-      if (local_jwt != null){
-            var decoded = jwt_decode(local_jwt);
-            var currentTime = Math.floor((new Date).getTime()/1000);
-            if (decoded.exp < currentTime){
-                localStorage.removeItem("encoded_token");
-                login();
-            } else{
-              $("#nav-bar-login")
-                .replaceWith('<button class="btn btn-small btn-outline-success p-0" id="logout123"> ' +
-                  '<a class="nav-link" href="/logout">Logout</a> ' +
-                  '</button>');
-              $('#logout123').on('click', function(e) {
-                localStorage.removeItem("encoded_token");
-              });
-            }
-        }
-      else {
-        login();
-      }
-      function login() {
-       $("#nav-bar-login")
-         .replaceWith('<a href="/api/auth/login">Sign In With <span class="fa fa-github fa-lg"></span></a>')
-      }
     </script>
   </body>
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,15 +35,13 @@
           </ul>
 
           <ul class="nav navbar-nav navbar-right">
-            {% if not user %}
+            {% if current_user == None %}
               <li>
                 <a href="/api/auth/login">Sign In With <span class="fa fa-github fa-lg"></span></a>
               </li>
             {% else %}
               <li>
-                <button class="btn btn-small btn-outline-success p-0">
-                  <a class="nav-link" href="/logout">Logout</a>
-                </button>
+                <a class="nav-link" href="/logout">Logout</a>
               </li>
             {% endif %}
           </ul>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -4,12 +4,6 @@
 Dashboard {{user.name}}
 {% endblock %}
 
-{% block scripts%}
-<script>
-localStorage.setItem("encoded_token","{{encoded_token}}");
-window.history.pushState("", "Dashboard", "/");
-</script>
-{% endblock %}
 {% block content %}
 <div class="container">
     {% if user.email != None %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,28 +1,34 @@
 {% extends "base.html" %}
 
 {% block title %}
-Dashboard {{user.name}}
+Dashboard {{current_user.name}}
+{% endblock %}
+
+{% block scripts%}
+<script>
+window.history.pushState("", "Dashboard", "/");
+</script>
 {% endblock %}
 
 {% block content %}
 <div class="container">
-    {% if user.email != None %}
+    {% if current_user.email != None %}
 	<div class="row  justify-content-center">
 	  <div class="col-4">
         <br>
-        <img src="{{user.email | gravatar(size=50)}}" class="img-thumbnail"/>
+        <img src="{{current_user.email | gravatar(size=50)}}" class="img-thumbnail"/>
         <br>
         <br>
         <span class="fa fa-envelope"></span>
-        <span class="help-block">{{user.email}}</span>
+        <span class="help-block">{{current_user.email}}</span>
   	  </div>
 	</div>
     {% endif %}
 	<div>
 		<h1>
-			Welcome {{user.name}}!
+			Welcome {{current_user.name}}!
 		</h1>
-		<h5>Your Access Token: {{user.secret}}</h5>
+		<h5>Your Access Token: {{current_user.secret}}</h5>
 	</div>
 	<div>
 		<h3>Start publishing your data packages in 3 easy steps:</h3>
@@ -36,9 +42,9 @@ Install dpmpy, the data package manager  command line tool:
 Set your configuration:
 
 	$ dpmpy configure
-	> Username:  # {{user.name}}
+	> Username:  # {{current_user.name}}
 	# Use your secret token here (also visible at the top of the page)
-	> Your access_token:  # {{user.secret}}
+	> Your access_token:  # {{current_user.secret}}
 	# Use server url Eg: https://staging.datapackaged.com/
 	> Server URL:
 

--- a/tests/site/test_controller.py
+++ b/tests/site/test_controller.py
@@ -299,7 +299,7 @@ class SignupEndToEndTestCase(unittest.TestCase):
 
                     # Checking User Object passed with context
                     self.assertEqual(self.oAuth_user_info[
-                                         'login'], context['user'].name)
+                                         'login'], context['current_user'].name)
 
                     # Dashboad loaded with status code 200
                     self.assertEqual(rv.status_code, 200)

--- a/tests/site/test_controller.py
+++ b/tests/site/test_controller.py
@@ -301,9 +301,6 @@ class SignupEndToEndTestCase(unittest.TestCase):
                     self.assertEqual(self.oAuth_user_info[
                                          'login'], context['user'].name)
 
-                    # Token sent along with context (For login)
-                    self.assertIn('encoded_token', context)
-
                     # Dashboad loaded with status code 200
                     self.assertEqual(rv.status_code, 200)
 


### PR DESCRIPTION
 we use JWT and store them in localstorage. Since these are not sent as
 part of the request to the server there is no way for the server
 to know if user is authenticated.

 We will store jwt inside cookie, so that we know user is authenticated ?

   * Added set cookie in callback handler
   * Added cookie unset method in logout
   * Added get_user_from_cookie method to extract user from cookie.
   * Update all site urls. If JWT is invalid all will redirect to /logout page.
   * Update base.html navbar login/logout button based on user variable from backend.
     * Removed all relative js code.
   * Removed encoded_token storing js method.

   Additional Fixes
   * Update JWT expiration_hour to 24.
   * Updated search swagger doc.

Resolves : #292