### PR TITLE
[publish][m] fix wrong authorization detection

### DIFF
--- a/app/auth/controllers.py
+++ b/app/auth/controllers.py
@@ -203,7 +203,7 @@ def authorize_upload():
         publisher, package_name = metadata['owner'], metadata['name']
         res_payload = {'filedata': {}}
 
-        if Package.is_package_exists(package_name):
+        if Package.is_package_exists(publisher, package_name):
             status = check_is_authorized('Package::Update', publisher, package_name, user_id)
         else:
             status = check_is_authorized('Package::Create', publisher, package_name, user_id)

--- a/app/package/controllers.py
+++ b/app/package/controllers.py
@@ -372,7 +372,7 @@ def finalize_publish():
         if jwt_status:
             user_id = user_info['user']
 
-        if Package.is_package_exists(package):
+        if Package.is_package_exists(publisher, package):
             status = check_is_authorized('Package::Update', publisher, package, user_id)
         else:
             status = check_is_authorized('Package::Create', publisher, package, user_id)

--- a/app/package/models.py
+++ b/app/package/models.py
@@ -382,6 +382,6 @@ class Package(db.Model):
         """
         instance = Package.query.join(Publisher)\
             .filter(Package.name == package_name,
-                    Publisher.name == publisher_name).first()
+                    Publisher.name == publisher_name).all()
         return len(instance) > 0
 

--- a/app/package/models.py
+++ b/app/package/models.py
@@ -373,13 +373,15 @@ class Package(db.Model):
             return None
 
     @staticmethod
-    def is_package_exists(package_name):
+    def is_package_exists(publisher_name, package_name):
         """
         This method will check package with the name already exists or not
+        :param publisher_name: publisher name
         :param package_name: package name
         :return: True is data already exists else false
         """
-        instance = Package.query \
-            .filter(Package.name == package_name).all()
+        instance = Package.query.join(Publisher)\
+            .filter(Package.name == package_name,
+                    Publisher.name == publisher_name).first()
         return len(instance) > 0
 

--- a/tests/auth/test_controller.py
+++ b/tests/auth/test_controller.py
@@ -196,7 +196,7 @@ class AuthorizeUploadTestCase(unittest.TestCase):
             self.user.email, self.user.name, self.user.secret = \
                 'test@test.com', self.publisher, 'super_secret'
             self.pub = Publisher(name=self.publisher)
-            self.pub.packages.append(Package(name='test_package'))
+            self.pub.packages.append(Package(name=self.package))
             association = PublisherUser(role=UserRoleEnum.owner)
             association.publisher = self.pub
             self.user.publishers.append(association)

--- a/tests/package/test_models.py
+++ b/tests/package/test_models.py
@@ -453,9 +453,9 @@ class PackageTestCase(unittest.TestCase):
         self.assertEqual(latest_data.readme, tagged_data.readme)
 
     def test_is_package_exists(self):
-        status = Package.is_package_exists(self.package_one)
+        status = Package.is_package_exists(self.publisher_one, self.package_one)
         self.assertTrue(status)
-        status = Package.is_package_exists('non-exists-package')
+        status = Package.is_package_exists(self.publisher_one, 'non-exists-package')
         self.assertFalse(status)
 
     def tearDown(self):


### PR DESCRIPTION
We were facing 400 unauthorized error while publishing datapackage.
Package.is_package_exists was detection wrongly the exists. So we were
trying for Package::Update authorization instead of Package::Create.