### PR TITLE
[m] add limit option in search

### DIFF
--- a/app/search/controllers.py
+++ b/app/search/controllers.py
@@ -46,7 +46,14 @@ def search_packages():
         q = request.args.get('q')
         if q is None:
             q = ''
-        result = DataPackageQuery(query_string=q.strip()).get_data(20)
+        limit = request.args.get('limit')
+        try:
+            limit = int(limit)
+        except (ValueError, TypeError):
+            limit = 20
+
+        result = DataPackageQuery(query_string=q.strip())\
+            .get_data(limit=limit)
         return jsonify(dict(items=result, total_count=len(result)))
     except Exception as e:
         app.logger.error(e)

--- a/app/search/controllers.py
+++ b/app/search/controllers.py
@@ -47,13 +47,9 @@ def search_packages():
         if q is None:
             q = ''
         limit = request.args.get('limit')
-        try:
-            limit = int(limit)
-        except (ValueError, TypeError):
-            limit = 20
 
-        result = DataPackageQuery(query_string=q.strip())\
-            .get_data(limit=limit)
+        result = DataPackageQuery(query_string=q.strip(),
+                                  limit=limit).get_data()
         return jsonify(dict(items=result, total_count=len(result)))
     except Exception as e:
         app.logger.error(e)

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -13,8 +13,12 @@ from app.profile.models import Publisher
 
 class DataPackageQuery(object):
 
-    def __init__(self, query_string):
+    def __init__(self, query_string, limit=None):
         self.query_string = query_string
+        try:
+            self.limit = min(int(limit), 1000)
+        except (ValueError, TypeError):
+            self.limit = 20
 
     def _build_sql_query(self, query, query_filters):
 
@@ -50,13 +54,12 @@ class DataPackageQuery(object):
                 break
         return qu, qu_filters
 
-    def get_data(self, limit=None):
+    def get_data(self):
         data_list = []
         q, qf = self._parse_query_string()
-        if limit is None:
-            results = self._build_sql_query(q, qf).all()
-        else:
-            results = self._build_sql_query(q, qf).limit(limit)
+
+        results = self._build_sql_query(q, qf).limit(self.limit)
+
         for result in results:
             data = result.__dict__
             data['descriptor'] = data['descriptor']

--- a/app/site/controllers.py
+++ b/app/site/controllers.py
@@ -127,7 +127,7 @@ def search_package():
     q = request.args.get('q')
     if q is None:
         q = ''
-    datapackage_list = DataPackageQuery(query_string=q.strip()).get_data(20)
+    datapackage_list = DataPackageQuery(query_string=q.strip()).get_data(1000)
     return render_template("search.html",
                            datapackage_list=datapackage_list,
                            total_count=len(datapackage_list),

--- a/app/site/controllers.py
+++ b/app/site/controllers.py
@@ -127,7 +127,8 @@ def search_package():
     q = request.args.get('q')
     if q is None:
         q = ''
-    datapackage_list = DataPackageQuery(query_string=q.strip()).get_data(1000)
+    datapackage_list = DataPackageQuery(query_string=q.strip(),
+                                        limit=1000).get_data()
     return render_template("search.html",
                            datapackage_list=datapackage_list,
                            total_count=len(datapackage_list),

--- a/tests/search/test_controllers.py
+++ b/tests/search/test_controllers.py
@@ -58,6 +58,30 @@ class SearchPackagesTestCase(unittest.TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(6, len(result['items']))
 
+    def test_should_return_max_result_set_by_limit(self):
+        url = "/api/search/package?limit=3"
+        response = self.client.get(url)
+        result = json.loads(response.data)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(3, len(result['items']))
+
+    def test_should_return_20_result_if_limit_invalid(self):
+        with self.app.test_request_context():
+            pub = Publisher(name='big_publisher')
+            for i in range(0, 30):
+                pub.packages\
+                    .append(Package(name='pack{i}'.format(i=i),
+                                    descriptor={"title": "pack1 details one"},
+                                    readme="Big readme one"))
+            db.session.add(pub)
+            db.session.commit()
+
+        url = "/api/search/package?limit=lem"
+        response = self.client.get(url)
+        result = json.loads(response.data)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(20, len(result['items']))
+
     def tearDown(self):
         with self.app.app_context():
             db.session.remove()

--- a/tests/search/test_models.py
+++ b/tests/search/test_models.py
@@ -126,12 +126,16 @@ class DataPackageQueryTestCase(unittest.TestCase):
     def test_should_return_data_package_with_limit(self):
 
         query_string = "details publisher:pub1"
-        dpq = DataPackageQuery(query_string)
-        self.assertEqual(3, len(dpq.get_data(limit=5)))
+        dpq = DataPackageQuery(query_string, limit=5)
+        self.assertEqual(3, len(dpq.get_data()))
 
         query_string = "details publisher:pub1 publisher:pub2"
-        dpq = DataPackageQuery(query_string)
-        self.assertEqual(3, len(dpq.get_data(limit=3)))
+        dpq = DataPackageQuery(query_string, limit=3)
+        self.assertEqual(3, len(dpq.get_data()))
+
+    def test_limit_should_be_maximum_1000(self):
+        dpq = DataPackageQuery('details publisher:pub1', limit=1005)
+        self.assertEqual(1000, dpq.limit)
 
     def tearDown(self):
         with self.app.app_context():


### PR DESCRIPTION
Added limit option in search API. If any wrong value passed for limit
it set to 20.
Increased the limit value for search page to 1000.

Resolves : #294