### PR TITLE
[m] change SQL-Alchemy first call to one

### DIFF
--- a/app/package/models.py
+++ b/app/package/models.py
@@ -380,7 +380,7 @@ class Package(db.Model):
         try:
             instance = Package.query.join(Publisher) \
                 .filter(Package.name == package_name,
-                        Publisher.name == publisher_name).first()
+                        Publisher.name == publisher_name).one()
             return instance
         except Exception as e:
             app.logger.error(e)


### PR DESCRIPTION
Previously in Package model we had publisher name, package name
and version as an unique key. That is why filter call with publisher
name and package name was returning multiple rows.

But now in Package model publisher name and package name is unique
key. So there must be only one row for filtering publisher name and
package name. That is why first method call is ambiguous.
Changing to one method call.

Resolves : #313