### PR TITLE
[m] change SQL-Alchemy first call to one

### DIFF
--- a/app/auth/controllers.py
+++ b/app/auth/controllers.py
@@ -7,6 +7,8 @@ from __future__ import unicode_literals
 from flask import Blueprint, request, render_template, \
     jsonify, session, make_response, g
 from flask import current_app as app
+from sqlalchemy.orm.exc import NoResultFound
+
 from app.profile.models import User
 from app.auth.models import JWT, FileData
 from app.package.models import Package
@@ -125,8 +127,10 @@ def get_jwt():
                                 'secret can not be empty',
                                 400)
         elif user_name is not None:
-            user = User.query.filter_by(name=user_name).first()
-            if user is None:
+            try:
+                user = User.query.filter_by(name=user_name).one()
+            except NoResultFound as e:
+                app.logger.error(e)
                 return handle_error('USER_NOT_FOUND',
                                     'user does not exists',
                                     404)
@@ -134,8 +138,10 @@ def get_jwt():
                 verify = True
                 user_id = user.id
         elif email is not None:
-            user = User.query.filter_by(email=email).first()
-            if user is None:
+            try:
+                user = User.query.filter_by(email=email).one()
+            except NoResultFound as e:
+                app.logger.error(e)
                 return handle_error('USER_NOT_FOUND',
                                     'user does not exists',
                                     404)


### PR DESCRIPTION
Previously we were using auth0. There email id was not unique.
We were elying on auth0 user id. But now we are using github
for authentication. We changed the DB model to
email = db.Column(db.TEXT, unique=True, index=True)
So email supposed to be unique.

That is why changing SQL-alchemy's first method call to one.
Also add Exception handling, as if there is no data SQL-alchemy
throws, NoResultFound exception.

Resolves : #310