### PR TITLE
Data package readme in safe mode and supports GFM

### DIFF
--- a/app/site/controllers.py
+++ b/app/site/controllers.py
@@ -12,7 +12,7 @@ from app.site.models import Packaged
 from app.package.models import BitStore
 from app.profile.models import User, Publisher
 from app.search.models import DataPackageQuery
-from markdown import markdown
+from app.utils.helpers import text_to_markdown
 from BeautifulSoup import BeautifulSoup
 
 site_blueprint = Blueprint('site', __name__)
@@ -59,13 +59,15 @@ def datapackage_show(publisher, package):
         pass
     packaged = Packaged(metadata)
     dataset = packaged.construct_dataset(request.url_root)
+    dataset["readme"] = text_to_markdown(dataset["readme"])
+
     dataViews = packaged.get_views()
 
     bitstore = BitStore(publisher, package)
     datapackage_json_url_in_s3 = bitstore. \
         build_s3_object_url(request.headers['Host'],
                             'datapackage.json')
-    readme_short_markdown = markdown(metadata.get('readme', ''))
+    readme_short_markdown = text_to_markdown(metadata.get('readme', ''))
     readme_short = ''.join(BeautifulSoup(readme_short_markdown).findAll(text=True)) \
         .split('\n\n')[0].replace(' \n', '') \
         .replace('\n', ' ').replace('/^ /', '')

--- a/app/templates/_snippets.html
+++ b/app/templates/_snippets.html
@@ -124,7 +124,7 @@
   <div class="row moreinfo">
     <div class="col-md-8">
       <h2 id="readme">README</h2>
-      <div class="readme">{{dataset.readme|markdown}}</div>
+      <div class="readme">{{dataset.readme|safe}}</div>
     </div>
     <div class="col-md-4"></div>
   </div>

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from markdown import markdown
+from mdx_gfm import GithubFlavoredMarkdownExtension
+import bleach
+
+def text_to_markdown(text):
+    """ This method takes any text and sanitizes it from unsafe html tags.
+    Then it converts any markdown syntax into html and returns the result.
+    """
+    ALLOWED_TAGS = [
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'h7', 'h8', 'br', 'b', 'i',
+        'strong', 'em', 'a', 'pre', 'code', 'img', 'tt', 'div', 'ins', 'del',
+        'sup', 'sub', 'p', 'ol', 'ul', 'table', 'thead', 'tbody', 'tfoot',
+        'blockquote', 'dl', 'dt', 'dd', 'kbd', 'q', 'samp', 'var', 'hr', 'ruby',
+        'rt', 'rp', 'li', 'tr', 'td', 'th', 's', 'strike', 'summary', 'details'
+    ]
+    ALLOWED_ATTRIBUTES = {
+        '*': [
+                'abbr', 'accept', 'accept-charset', 'accesskey', 'action',
+                'align', 'alt', 'axis', 'border', 'cellpadding', 'cellspacing',
+                'char', 'charoff', 'charset', 'checked', 'clear', 'cols',
+                'colspan', 'color', 'compact', 'coords', 'datetime', 'dir',
+                'disabled', 'enctype', 'for', 'frame', 'headers', 'height',
+                'hreflang', 'hspace', 'ismap', 'label', 'lang', 'maxlength',
+                'media', 'method', 'multiple', 'name', 'nohref', 'noshade',
+                'nowrap', 'open', 'prompt', 'readonly', 'rel', 'rev', 'rows',
+                'rowspan', 'rules', 'scope', 'selected', 'shape', 'size',
+                'span', 'start', 'summary', 'tabindex', 'target', 'title',
+                'type', 'usemap', 'valign', 'value', 'vspace', 'width',
+                'itemprop'
+            ],
+        'a': ['href'],
+        'img': ['src', 'longdesc'],
+        'div': ['itemscope', 'itemtype'],
+        'blockquote': ['cite'],
+        'del': ['cite'],
+        'ins': ['cite'],
+        'q': ['cite']
+    }
+
+    sanitizedText = bleach.clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES)
+    markdown_to_safe_html = markdown(sanitizedText,
+                             extensions=[GithubFlavoredMarkdownExtension()])
+    return markdown_to_safe_html

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ boto3==1.4.3
 flasgger==0.5.13
 python-dotenv==0.6.0
 PyJWT==1.4.2
-py-gfm=0.1.3
+py-gfm==0.1.3
 Flask-Migrate==2.0.0
 Flask-Script==2.0.5
 psycopg2==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bleach==2.0.0
 flask==0.11
 flask-cors==3.0.2
 Flask-SQLAlchemy==2.1
@@ -8,6 +9,7 @@ boto3==1.4.3
 flasgger==0.5.13
 python-dotenv==0.6.0
 PyJWT==1.4.2
+py-gfm=0.1.3
 Flask-Migrate==2.0.0
 Flask-Script==2.0.5
 psycopg2==2.6.2

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from app.utils.helpers import text_to_markdown
+import unittest
+
+class HelpersTestCase(unittest.TestCase):
+    def test_allowed_tags_working(self):
+        self.assertEqual(text_to_markdown("<h1>test</h1>"), "<h1>test</h1>")
+
+    def test_disallowed_tags(self):
+        self.assertEqual(text_to_markdown("<script>test</script>"),
+                         "<p>&lt;script&gt;test&lt;/script&gt;</p>")
+
+    def test_allowed_attr_working(self):
+        self.assertEqual(text_to_markdown(
+                "<a href='https://example.com'>test</a>"
+            ),
+            '<p><a href="https://example.com">test</a></p>')


### PR DESCRIPTION
- `utils/helpers.py` for sanitizing README and converting markdown into safe html
- `tests/utils/test_helpers.py` tests for helpers
- refactored `app/site/controllers.py` to use helpers
- `_snippets.html` - we don't convert markdown to html anymore in templates