### PR TITLE
Embed data package json in readme

### DIFF
--- a/app/site/controllers.py
+++ b/app/site/controllers.py
@@ -12,7 +12,7 @@ from app.site.models import Packaged
 from app.package.models import BitStore
 from app.profile.models import User, Publisher
 from app.search.models import DataPackageQuery
-from app.utils.helpers import text_to_markdown
+from app.utils.helpers import text_to_markdown, dp_in_readme
 from BeautifulSoup import BeautifulSoup
 
 site_blueprint = Blueprint('site', __name__)
@@ -59,7 +59,9 @@ def datapackage_show(publisher, package):
         pass
     packaged = Packaged(metadata)
     dataset = packaged.construct_dataset(request.url_root)
-    dataset["readme"] = text_to_markdown(dataset["readme"])
+    
+    readme_variables_replaced = dp_in_readme(dataset["readme"], dataset)
+    dataset["readme"] = text_to_markdown(readme_variables_replaced)
 
     dataViews = packaged.get_views()
 

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -7,6 +7,9 @@ from __future__ import unicode_literals
 from markdown import markdown
 from mdx_gfm import GithubFlavoredMarkdownExtension
 import bleach
+import re
+import json
+
 
 def text_to_markdown(text):
     """ This method takes any text and sanitizes it from unsafe html tags.
@@ -48,3 +51,20 @@ def text_to_markdown(text):
                                 tags=ALLOWED_TAGS,
                                 attributes=ALLOWED_ATTRIBUTES)
     return sanitized_html
+
+
+def dp_in_readme(readme, dp):
+    """ This method takes a readme and data package as arguments. If there is dp
+    variables in readme, it returns readme with datapackage json embed into it.
+    Dp variables must be wrapped in double curly braces and can be one of:
+    datapackage.json, datapackage, dp.json, dp.
+    """
+    regex = "({{ ?)(datapackage(\.json)?|dp(\.json)?)( ?}})"
+    dp_copy = dict(dp)
+    if 'readme' in dp_copy:
+        dp_copy.pop('readme')
+    if 'owner' in dp_copy:
+        dp_copy.pop('owner')
+    dp_as_md = '\n```json\n' + json.dumps(dp_copy, indent=2) + '\n```\n'
+    readme_with_dp = re.sub(regex, dp_as_md, readme)
+    return readme_with_dp

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -54,10 +54,10 @@ def text_to_markdown(text):
 
 
 def dp_in_readme(readme, dp):
-    """ This method takes a readme and data package as arguments. If there is dp
-    variables in readme, it returns readme with datapackage json embed into it.
-    Dp variables must be wrapped in double curly braces and can be one of:
-    datapackage.json, datapackage, dp.json, dp.
+    """ This method takes a readme and data package descriptor as arguments. If
+    there is dp variables in readme, it returns readme with datapackage json
+    embed into it. Dp variables must be wrapped in double curly braces and can
+    be one of: datapackage.json, datapackage, dp.json, dp.
     """
     regex = "({{ ?)(datapackage(\.json)?|dp(\.json)?)( ?}})"
     dp_copy = dict(dp)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -4,8 +4,10 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from app.utils.helpers import text_to_markdown
+from app.utils.helpers import text_to_markdown, dp_in_readme
 import unittest
+import json
+
 
 class HelpersTestCase(unittest.TestCase):
     def test_allowed_tags_working(self):
@@ -24,3 +26,19 @@ class HelpersTestCase(unittest.TestCase):
     def test_blockquotes_working(self):
         self.assertEqual(text_to_markdown("> this is a blockquote"),
             '<blockquote>\n<p>this is a blockquote</p>\n</blockquote>')
+
+
+class DpInReadmeTestCase(unittest.TestCase):
+    def test_dp_in_readme(self):
+        dp = {
+            'name': 'test',
+            'resources': []
+        }
+        readme_with_variable = '# Title\n ## DP:\n {{ dp.json }}'
+        readme_without_variable = '# Title\n ## DP:\n description'
+        dp_expected = '# Title\n ## DP:\n '
+        dp_expected += '\n```json\n' + json.dumps(dp, indent=2) + '\n```\n'
+
+        self.assertEqual(dp_in_readme(readme_with_variable, dp), dp_expected)
+        self.assertEqual(dp_in_readme(readme_without_variable, dp),
+                        readme_without_variable)


### PR DESCRIPTION
This PR includes:
- `app/utils/helpers.py` - new method for searching data package variables and replacing it with dp descriptor as markdown code snippet
- `tests/utils/test_helpers.py` - tests for the new method
- `app/site/controllers.py` - refactored to replace dp variables in readme before converting to HTML