### PR TITLE
Error handling

### DIFF
--- a/app/package/controllers.py
+++ b/app/package/controllers.py
@@ -82,8 +82,6 @@ def tag_data_package(publisher, package):
         status_db = Package.create_or_update_tag(publisher, package, data['version'])
         status_bitstore = bitstore.copy_to_new_version(data['version'])
 
-        if status_db is False or status_bitstore is False:
-            raise Exception("failed to tag data package")
         return jsonify({"status": "OK"}), 200
     except Exception as e:
         app.logger.error(e)
@@ -133,10 +131,6 @@ def delete_data_package(publisher, package):
         status_db = Package.change_status(publisher, package, PackageStateEnum.deleted)
         if status_acl and status_db:
             return jsonify({"status": "OK"}), 200
-        if not status_acl:
-            raise Exception('Failed to change acl')
-        if not status_db:
-            raise Exception('Failed to change status')
     except Exception as e:
         app.logger.error(e)
         return handle_error('GENERIC_ERROR', e.message, 500)
@@ -187,10 +181,6 @@ def undelete_data_package(publisher, package):
         status_db = Package.change_status(publisher, package, PackageStateEnum.active)
         if status_acl and status_db:
             return jsonify({"status": "OK"}), 200
-        if not status_acl:
-            raise Exception('Failed to change acl')
-        if not status_db:
-            raise Exception('Failed to change status')
     except Exception as e:
         app.logger.error(e)
         return handle_error('GENERIC_ERROR', e.message, 500)
@@ -240,10 +230,6 @@ def purge_data_package(publisher, package):
         status_db = Package.delete_data_package(publisher, package)
         if status_acl and status_db:
             return jsonify({"status": "OK"}), 200
-        if not status_acl:
-            raise Exception('Failed to delete from s3')
-        if not status_db:
-            raise Exception('Failed to delete from db')
     except Exception as e:
         app.logger.error(e)
         return handle_error('GENERIC_ERROR', e.message, 500)

--- a/app/package/models.py
+++ b/app/package/models.py
@@ -357,14 +357,10 @@ class Package(db.Model):
         :param package_name: package name
         :return: data package object based on the filter.
         """
-        try:
-            instance = Package.query.join(Publisher) \
-                .filter(Package.name == package_name,
-                        Publisher.name == publisher_name).one()
-            return instance
-        except Exception as e:
-            app.logger.error(e)
-            return None
+        instance = Package.query.join(Publisher) \
+            .filter(Package.name == package_name,
+                    Publisher.name == publisher_name).one_or_none()
+        return instance
 
     @staticmethod
     def is_package_exists(publisher_name, package_name):

--- a/app/package/models.py
+++ b/app/package/models.py
@@ -14,6 +14,7 @@ from flask import current_app as app
 from sqlalchemy.orm import relationship
 from app.profile.models import Publisher
 from app.database import db
+from botocore.exceptions import ClientError
 
 
 class BitStore(object):
@@ -66,7 +67,9 @@ class BitStore(object):
             s3_client = app.config['S3']
             response = s3_client.get_object(Bucket=bucket_name, Key=key)
             return response['Body'].read()
-        except Exception:
+        except ClientError as e:
+            if e.response['Error']['Code'] != 'NoSuchKey':
+                raise e
             return None
 
     def get_readme_object_key(self):
@@ -77,7 +80,7 @@ class BitStore(object):
         :return: Value of the readme key if found else None
         :rtype: None or Str
         """
-        readme_key = None
+        readme_key = 'None'
         prefix = self.build_s3_key('')
         bucket_name = app.config['S3_BUCKET_NAME']
         s3_client = app.config['S3']

--- a/app/package/models.py
+++ b/app/package/models.py
@@ -162,24 +162,21 @@ class BitStore(object):
         This method is used for Hard delete data packages.
         :return: Status True if able to delete or False if exception
         """
-        try:
-            bucket_name = app.config['S3_BUCKET_NAME']
-            s3_client = app.config['S3']
+        bucket_name = app.config['S3_BUCKET_NAME']
+        s3_client = app.config['S3']
 
-            keys = []
-            list_objects = s3_client.list_objects(Bucket=bucket_name,
-                                                  Prefix=self.build_s3_base_prefix())
-            if list_objects is not None and 'Contents' in list_objects:
-                for ob in s3_client \
-                    .list_objects(Bucket=bucket_name,
-                                  Prefix=self.build_s3_base_prefix())['Contents']:
-                    keys.append(dict(Key=ob['Key']))
+        keys = []
+        list_objects = s3_client.list_objects(Bucket=bucket_name,
+                                              Prefix=self.build_s3_base_prefix())
+        if list_objects is not None and 'Contents' in list_objects:
+            for ob in s3_client \
+                .list_objects(Bucket=bucket_name,
+                              Prefix=self.build_s3_base_prefix())['Contents']:
+                keys.append(dict(Key=ob['Key']))
 
-            s3_client.delete_objects(Bucket=bucket_name, Delete=dict(Objects=keys))
-            return True
-        except Exception as e:
-            app.logger.error(e)
-            return False
+        s3_client.delete_objects(Bucket=bucket_name, Delete=dict(Objects=keys))
+        return True
+
 
     def change_acl(self, acl):
         """
@@ -188,49 +185,41 @@ class BitStore(object):
         This method is used for Soft delete data packages.
         :return: Status True if able to delete or False if exception
         """
-        try:
-            bucket_name = app.config['S3_BUCKET_NAME']
-            s3_client = app.config['S3']
+        bucket_name = app.config['S3_BUCKET_NAME']
+        s3_client = app.config['S3']
 
-            keys = []
-            list_objects = s3_client.list_objects(Bucket=bucket_name,
-                                                  Prefix=self.build_s3_base_prefix())
-            if list_objects is not None and 'Contents' in list_objects:
-                for ob in s3_client \
-                    .list_objects(Bucket=bucket_name,
-                                  Prefix=self.build_s3_base_prefix())['Contents']:
-                    keys.append(ob['Key'])
+        keys = []
+        list_objects = s3_client.list_objects(Bucket=bucket_name,
+                                              Prefix=self.build_s3_base_prefix())
+        if list_objects is not None and 'Contents' in list_objects:
+            for ob in s3_client \
+                .list_objects(Bucket=bucket_name,
+                              Prefix=self.build_s3_base_prefix())['Contents']:
+                keys.append(ob['Key'])
 
-            for key in keys:
-                s3_client.put_object_acl(Bucket=bucket_name, Key=key,
-                                         ACL=acl)
-        except Exception as e:
-            app.logger.error(e)
-            return False
+        for key in keys:
+            s3_client.put_object_acl(Bucket=bucket_name, Key=key,
+                                     ACL=acl)
         return True
 
     def copy_to_new_version(self, version):
-        try:
-            bucket_name = app.config['S3_BUCKET_NAME']
-            s3_client = app.config['S3']
-            latest_keys = []
-            list_objects = s3_client.list_objects(Bucket=bucket_name,
-                                                  Prefix=self.build_s3_versioned_prefix())
-            if list_objects is not None and 'Contents' in list_objects:
-                for ob in s3_client \
-                    .list_objects(Bucket=bucket_name,
-                                  Prefix=self.build_s3_versioned_prefix())['Contents']:
-                    latest_keys.append(ob['Key'])
-            for key in latest_keys:
-                versioned_key = key.replace('/latest/', '/{0}/'.format(version))
-                copy_source = {'Bucket': bucket_name, 'Key': key}
-                s3_client.copy_object(Bucket=bucket_name,
-                                      Key=versioned_key,
-                                      CopySource=copy_source)
-            return True
-        except Exception as e:
-            app.logger.error(e)
-            return False
+        bucket_name = app.config['S3_BUCKET_NAME']
+        s3_client = app.config['S3']
+        latest_keys = []
+        list_objects = s3_client.list_objects(Bucket=bucket_name,
+                                              Prefix=self.build_s3_versioned_prefix())
+        if list_objects is not None and 'Contents' in list_objects:
+            for ob in s3_client \
+                .list_objects(Bucket=bucket_name,
+                              Prefix=self.build_s3_versioned_prefix())['Contents']:
+                latest_keys.append(ob['Key'])
+        for key in latest_keys:
+            versioned_key = key.replace('/latest/', '/{0}/'.format(version))
+            copy_source = {'Bucket': bucket_name, 'Key': key}
+            s3_client.copy_object(Bucket=bucket_name,
+                                  Key=versioned_key,
+                                  CopySource=copy_source)
+        return True
 
     @staticmethod
     def extract_information_from_s3_url(url):
@@ -270,33 +259,29 @@ class Package(db.Model):
 
     @staticmethod
     def create_or_update_tag(publisher_name, package_name, tag):
-        try:
-            package = Package.query.join(Publisher)\
-                .filter(Publisher.name == publisher_name,
-                        Package.name == package_name).one()
+        package = Package.query.join(Publisher)\
+            .filter(Publisher.name == publisher_name,
+                    Package.name == package_name).one()
 
-            data_latest = PackageTag.query.join(Package)\
-                .filter(Package.id == package.id,
-                        PackageTag.tag == 'latest').one()
+        data_latest = PackageTag.query.join(Package)\
+            .filter(Package.id == package.id,
+                    PackageTag.tag == 'latest').one()
 
-            tag_instance = PackageTag.query.join(Package) \
-                .filter(Package.id == package.id,
-                        PackageTag.tag == tag).first()
+        tag_instance = PackageTag.query.join(Package) \
+            .filter(Package.id == package.id,
+                    PackageTag.tag == tag).first()
 
-            update_props = ['descriptor', 'readme', 'package_id']
-            if tag_instance is None:
-                tag_instance = PackageTag()
+        update_props = ['descriptor', 'readme', 'package_id']
+        if tag_instance is None:
+            tag_instance = PackageTag()
 
-            for update_prop in update_props:
-                setattr(tag_instance, update_prop, getattr(data_latest, update_prop))
-            tag_instance.tag = tag
+        for update_prop in update_props:
+            setattr(tag_instance, update_prop, getattr(data_latest, update_prop))
+        tag_instance.tag = tag
 
-            db.session.add(tag_instance)
-            db.session.commit()
-            return True
-        except Exception as e:
-            app.logger.error(e)
-            return False
+        db.session.add(tag_instance)
+        db.session.commit()
+        return True
 
     @staticmethod
     def create_or_update(name, publisher_name, **kwargs):
@@ -338,17 +323,13 @@ class Package(db.Model):
         :param status: status of the package
         :return: If success True else False
         """
-        try:
-            data = Package.query.join(Publisher). \
-                filter(Publisher.name == publisher_name,
-                       Package.name == package_name).one()
-            data.status = status
-            db.session.add(data)
-            db.session.commit()
-            return True
-        except Exception as e:
-            app.logger.error(e)
-            return False
+        data = Package.query.join(Publisher). \
+            filter(Publisher.name == publisher_name,
+                   Package.name == package_name).one()
+        data.status = status
+        db.session.add(data)
+        db.session.commit()
+        return True
 
     @staticmethod
     def delete_data_package(publisher_name, package_name):
@@ -359,18 +340,14 @@ class Package(db.Model):
         :param package_name: package name
         :return: If success True else False
         """
-        try:
-            data = Package.query.join(Publisher). \
-                filter(Publisher.name == publisher_name,
-                       Package.name == package_name).one()
-            package_id = data.id
-            Package.query.filter(Package.id == package_id).delete()
-            # db.session.delete(meta_data)
-            db.session.commit()
-            return True
-        except Exception as e:
-            app.logger.error(e)
-            return False
+        data = Package.query.join(Publisher). \
+            filter(Publisher.name == publisher_name,
+                   Package.name == package_name).one()
+        package_id = data.id
+        Package.query.filter(Package.id == package_id).delete()
+        # db.session.delete(meta_data)
+        db.session.commit()
+        return True
 
     @staticmethod
     def get_package(publisher_name, package_name):

--- a/app/site/controllers.py
+++ b/app/site/controllers.py
@@ -14,6 +14,7 @@ from app.profile.models import User, Publisher
 from app.search.models import DataPackageQuery
 from app.utils.helpers import text_to_markdown, dp_in_readme
 from BeautifulSoup import BeautifulSoup
+from app.utils import handle_error
 
 site_blueprint = Blueprint('site', __name__)
 
@@ -52,14 +53,12 @@ def datapackage_show(publisher, package):
         app.test_client(). \
             get('/api/package/{publisher}/{package}'. \
                 format(publisher=publisher, package=package)).data)
-    try:
-        if metadata['error_code'] == 'DATA_NOT_FOUND':
-            return "404 Not Found", 404
-    except:
-        pass
+    if metadata.get('error_code') == 'DATA_NOT_FOUND':
+        return handle_error("NOT_FOUND","Page Not Found", 404)
+
     packaged = Packaged(metadata)
     dataset = packaged.construct_dataset(request.url_root)
-    
+
     readme_variables_replaced = dp_in_readme(dataset["readme"], dataset)
     dataset["readme"] = text_to_markdown(readme_variables_replaced)
 

--- a/tests/package/test_controller.py
+++ b/tests/package/test_controller.py
@@ -442,28 +442,28 @@ class SoftDeleteTestCase(unittest.TestCase):
     @patch('app.package.models.BitStore.change_acl')
     @patch('app.package.models.Package.change_status')
     def test_throw_500_if_change_acl_fails(self,  change_status, change_acl):
-        change_acl.return_value = False
+        change_acl.side_effect = Exception('failed')
         change_status.return_value = True
         response = self.client.delete(self.url, headers=dict(Authorization=self.auth))
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(data['message'], 'Failed to change acl')
+        self.assertEqual(data['message'], 'failed')
 
     @patch('app.package.models.BitStore.change_acl')
     @patch('app.package.models.Package.change_status')
     def test_throw_500_if_change_status_fails(self, change_status, change_acl):
         change_acl.return_value = True
-        change_status.return_value = False
+        change_status.side_effect = Exception('failed')
         response = self.client.delete(self.url, headers=dict(Authorization=self.auth))
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(data['message'], 'Failed to change status')
+        self.assertEqual(data['message'], 'failed')
 
     @patch('app.package.models.BitStore.change_acl')
     @patch('app.package.models.Package.change_status')
     def test_throw_generic_error_if_internal_error(self, change_status, change_acl):
         change_acl.side_effect = Exception('failed')
-        change_status.return_value = False
+        change_status.side_effect = Exception('failed')
         response = self.client.delete(self.url, headers=dict(Authorization=self.auth))
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 500)
@@ -548,24 +548,24 @@ class HardDeleteTestCase(unittest.TestCase):
     @patch('app.package.models.BitStore.delete_data_package')
     @patch('app.package.models.Package.delete_data_package')
     def test_throw_500_if_change_acl_fails(self, db_delete, bitstore_delete):
-        bitstore_delete.return_value = False
+        bitstore_delete.side_effect = Exception('failed')
         db_delete.return_value = True
         auth = "%s" % self.jwt
         response = self.client.delete(self.url, headers={'Auth-Token': auth})
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(data['message'], 'Failed to delete from s3')
+        self.assertEqual(data['message'], 'failed')
 
     @patch('app.package.models.BitStore.delete_data_package')
     @patch('app.package.models.Package.delete_data_package')
     def test_throw_500_if_change_status_fails(self, db_delete, bitstore_delete):
         bitstore_delete.return_value = True
-        db_delete.return_value = False
+        db_delete.side_effect = Exception('failed')
         auth = "%s" % self.jwt
         response = self.client.delete(self.url, headers={'Auth-Token': auth})
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(data['message'], 'Failed to delete from db')
+        self.assertEqual(data['message'], 'failed')
 
     @patch('app.package.models.BitStore.delete_data_package')
     @patch('app.package.models.Package.delete_data_package')
@@ -821,7 +821,7 @@ class TagDataPackageTestCase(unittest.TestCase):
     @patch('app.package.models.Package.create_or_update_tag')
     def test_throw_500_if_failed_to_tag(self, create_or_update_tag,
                                         copy_to_new_version):
-        copy_to_new_version.return_value = False
+        copy_to_new_version.side_effect = Exception('failed')
         create_or_update_tag.return_value = True
         response = self.client.post(self.url,
                                     data=json.dumps({
@@ -877,7 +877,7 @@ class TagDataPackageTestCase(unittest.TestCase):
     @patch('app.package.models.Package.create_or_update_tag')
     def test_allow_if_member_of_publisher(self, create_or_update_tag,
                                           copy_to_new_version):
-        copy_to_new_version.return_value = False
+        copy_to_new_version.side_effect = Exception('failed')
         create_or_update_tag.return_value = True
         response = self.client.post(self.jwt_url,
                                     data=json.dumps({

--- a/tests/package/test_models.py
+++ b/tests/package/test_models.py
@@ -149,7 +149,7 @@ class BitStoreTestCase(unittest.TestCase):
             s3.create_bucket(Bucket=bucket_name)
             read_me_key = bit_store.build_s3_key('test.md')
             s3.put_object(Bucket=bucket_name, Key=read_me_key, Body='')
-            self.assertEqual(bit_store.get_readme_object_key(), None)
+            self.assertEqual(bit_store.get_readme_object_key(), 'None')
 
     @mock_s3
     def test_return_none_if_object_found(self):
@@ -161,7 +161,7 @@ class BitStoreTestCase(unittest.TestCase):
             read_me_key = bit_store.build_s3_key('test.md')
             s3.put_object(Bucket=bucket_name, Key=read_me_key, Body='')
             self.assertEqual(bit_store.get_s3_object(read_me_key + "testing"), None)
-            self.assertEqual(bit_store.get_s3_object(None), None)
+            self.assertEqual(bit_store.get_s3_object('None'), None)
 
     @mock_s3
     def test_change_acl(self):

--- a/tests/package/test_models.py
+++ b/tests/package/test_models.py
@@ -405,11 +405,6 @@ class PackageTestCase(unittest.TestCase):
                    Package.name == self.package_one).one()
         self.assertEqual(PackageStateEnum.active, data.status)
 
-    def test_return_false_if_failed_to_change_status(self):
-        status = Package.change_status(self.publisher_one, 'fake_package',
-                                       status='active')
-        self.assertFalse(status)
-
     def test_return_true_if_delete_data_package_success(self):
         status = Package.delete_data_package(self.publisher_one,
                                              self.package_one)
@@ -420,11 +415,6 @@ class PackageTestCase(unittest.TestCase):
         self.assertEqual(0, len(data))
         data = Publisher.query.all()
         self.assertEqual(2, len(data))
-
-    def test_return_false_if_error_occur(self):
-        status = Package.delete_data_package("fake_package",
-                                             self.package_one)
-        self.assertFalse(status)
 
     def test_should_populate_new_versioned_data_package(self):
         Package.create_or_update_tag(self.publisher_one,


### PR DESCRIPTION
Code refactored to catch exceptions only in cases, when we are really handling it and not just returning `False`.
In case we are not specifically handling error it gets risen and handled as any other  500 Generic errors with specific error message Eg: `sqlalchemy.orm.exc.MultipleResultsFound()`

Tests updated were it was expecting True or False and now is expecting error

@rufuspollock I'd like you to review this PR as well, Esp: https://github.com/frictionlessdata/dpr-api/commit/bc2b9f6656624edbe150a7f56ca8a82aaa6d7358