### PR TITLE
Serialize Profile  part of API

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,6 +21,7 @@ from .database import db
 from .schemas import ma
 from app.auth.controllers import auth_blueprint, bitstore_blueprint
 from app.auth.models import JWT
+from app.logic import get_user_by_id
 from app.package.controllers import package_blueprint
 from app.site.controllers import site_blueprint
 from app.profile.controllers import profile_blueprint
@@ -148,5 +149,6 @@ def create_app():
         g.current_user = None
         if token:
             payload = JWT(app.config['JWT_SEED']).decode(token)
-            g.current_user = User().get_userinfo_by_id(payload['user'])
+            g.current_user = get_user_by_id(payload['user'])
+            
     return app

--- a/app/logic/__init__.py
+++ b/app/logic/__init__.py
@@ -54,6 +54,21 @@ def get_package(publisher, package):
 
     return datapackage
 
+
+def get_publisher(publisher):
+    '''
+    Returns publisher info from DB
+    '''
+
+    publisher_info = Publisher.query.filter_by(name=publisher).first()
+    if publisher_info is None:
+        raise InvalidUsage("Publisher not found", 404)
+    publisher_schema = schema.PublisherSchema()
+    info = publisher_schema.dump(publisher_info)
+
+    return info.data
+
+
 def get_metadata_for_package(publisher, package):
     '''
     Returns metadata for given package owned by publisher

--- a/app/logic/__init__.py
+++ b/app/logic/__init__.py
@@ -69,6 +69,19 @@ def get_publisher(publisher):
     return info.data
 
 
+def get_user_by_id(user_id):
+    '''
+    Returns user info by given id from DB
+    '''
+    user = User.query.filter_by(id=user_id).first()
+    if not user:
+        raise InvalidUsage("User not found", 404)
+    user_schema = schema.UserSchema()
+    user_info = user_schema.dump(user)
+
+    return user_info.data
+
+
 def get_metadata_for_package(publisher, package):
     '''
     Returns metadata for given package owned by publisher

--- a/app/logic/__init__.py
+++ b/app/logic/__init__.py
@@ -115,17 +115,16 @@ def get_authorized_user_info():
     resp = github.authorized_response()
     if resp is None or resp.get('access_token') is None:
         raise InvalidUsage('Access Denied', 400)
+
     session['github_token'] = (resp['access_token'], '')
-    user_info = github.get('user')
-    user_info = user_info.data
-    # in case user Email is not public
-    if not user_info.get('email'):
-        emails = github.get('user/emails').data
-        if not len(emails):
-            raise InvalidUsage('Email Not Found', 404)
-        for email in emails:
-            if email.get('primary'):
-                user_info['email'] = email.get('email')
+
+    user_info = github.get('user').data
+    emails = github.get('user/emails').data
+    user_info['emails'] = emails
+
+    user_info_schema = schema.UserInfoSchema()
+    user_info = user_info_schema.load(user_info).data
+
     return user_info
 
 

--- a/app/profile/controllers.py
+++ b/app/profile/controllers.py
@@ -6,8 +6,10 @@ from __future__ import unicode_literals
 
 from flask import Blueprint, jsonify
 from flask import current_app as app
-from app.utils import InvalidUsage
+from app.logic import get_publisher
 from app.profile.models import Publisher
+from app.schemas import PublisherSchema
+from app.utils import InvalidUsage
 
 profile_blueprint = Blueprint('profile', __name__, url_prefix='/api/profile')
 
@@ -62,7 +64,5 @@ def get_publisher_profile(name):
                             type: string
                             default: SUCCESS
         """
-    info = Publisher.get_publisher_info(name)
-    if info is None:
-        raise InvalidUsage("Publisher not found", 404)
+    info = get_publisher(name)
     return jsonify(dict(data=info, status="SUCCESS"))

--- a/app/profile/models.py
+++ b/app/profile/models.py
@@ -94,13 +94,6 @@ class User(db.Model):
             db.session.commit()
         return user
 
-    @staticmethod
-    def get_userinfo_by_id(user_id):
-        user = User.query.filter_by(id=user_id).first()
-        if user:
-            return user
-        return None
-
 
 class UserRoleEnum(enum.Enum):
     owner = "OWNER"

--- a/app/profile/models.py
+++ b/app/profile/models.py
@@ -34,23 +34,6 @@ class Publisher(db.Model):
     users = relationship("PublisherUser", back_populates="publisher",
                          cascade='save-update, merge, delete, delete-orphan')
 
-    @staticmethod
-    def get_publisher_info(name):
-        publisher = Publisher.query.filter_by(name=name).first()
-        if publisher is None:
-            return None
-        publisher_info = dict()
-        if publisher.contact_public:
-            contact = dict(phone=publisher.phone,
-                           email=publisher.email,
-                           country=publisher.country)
-            publisher_info['contact'] = contact
-        publisher_info['description'] = publisher.description
-        publisher_info['title'] = publisher.title
-        publisher_info['name'] = publisher.name
-        publisher_info['joined'] = publisher.created_at.strftime("%B %Y")
-        return publisher_info
-
 
 class User(db.Model):
     """

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -5,8 +5,11 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from flask_marshmallow import Marshmallow
+from marshmallow import pre_load
+
 from app.package.models import *
 from app.profile.models import *
+from app.utils import InvalidUsage
 
 ma = Marshmallow()
 
@@ -18,6 +21,27 @@ class PublisherSchema(ma.ModelSchema):
 class UserSchema(ma.ModelSchema):
     class Meta:
         model = User
+
+
+class UserInfoSchema(ma.Schema):
+    class Meta:
+        fields = ('email', 'login', 'name')
+
+    @pre_load
+    def load_user(self, data):
+        email = data.get('email')
+        emails = data.get('emails')
+
+        if email:
+            return data
+
+        if not emails or not len(emails):
+            raise InvalidUsage('Email Not Found', 404)
+
+        for email in emails:
+            if email.get('primary') == 'true':
+                data['email'] = email.get('email')
+                return data
 
 
 class PublisherUserSchema(ma.ModelSchema):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from flask_marshmallow import Marshmallow
-from marshmallow import pre_load
+from marshmallow import pre_load, pre_dump
 
 from app.package.models import *
 from app.profile.models import *
@@ -16,7 +16,26 @@ ma = Marshmallow()
 class PublisherSchema(ma.ModelSchema):
     class Meta:
         model = Publisher
+        dateformat = ("%B %Y")
 
+    id = ma.Field(load_only=True)
+    created_at = ma.Field(load_only=True)
+    phone = ma.Field(load_only=True)
+    private = ma.Field(load_only=True)
+    country = ma.Field(load_only=True)
+    email = ma.Field(load_only=True)
+    contact_public = ma.Field(load_only=True)
+    users = ma.Field(load_only=True)
+    packages = ma.Field(load_only=True)
+    contact = ma.Method('add_public_contact')
+    joined = ma.DateTime(attribute = 'created_at')
+
+    def add_public_contact(self, data):
+        if data.contact_public:
+            contact = dict(phone=data.phone,
+                           email=data.email,
+                           country=data.country)
+            return contact
 
 class UserSchema(ma.ModelSchema):
     class Meta:

--- a/app/site/controllers.py
+++ b/app/site/controllers.py
@@ -12,7 +12,7 @@ from app.package.models import BitStore
 from app.profile.models import User, Publisher
 from app.logic.search import DataPackageQuery
 from app.utils import InvalidUsage
-from app.logic import *
+from app.logic import get_package, get_publisher
 
 site_blueprint = Blueprint('site', __name__)
 
@@ -72,9 +72,8 @@ def datapackage_show(publisher, package):
 def publisher_dashboard(publisher):
     datapackage_list = DataPackageQuery(query_string="* publisher:{publisher}"
                                         .format(publisher=publisher)).get_data()
-    publisher = Publisher.get_publisher_info(publisher)
-    print (publisher)
 
+    publisher = get_publisher(publisher)
     return render_template("publisher.html",
                            publisher=publisher,
                            datapackage_list=datapackage_list), 200

--- a/tests/logic/test_logic.py
+++ b/tests/logic/test_logic.py
@@ -159,6 +159,17 @@ class PackageTest(unittest.TestCase):
         self.assertEqual(context.exception.status_code, 404)
 
 
+    def test_get_user_info(self):
+        publisher = get_user_by_id(1)
+        self.assertEqual(publisher['name'], self.publisher)
+
+
+    def test_get_user_info_throws_404_if_no_publisher_found(self):
+        with self.assertRaises(InvalidUsage) as context:
+            get_user_by_id(2)
+        self.assertEqual(context.exception.status_code, 404)
+
+
     def tearDown(self):
         with self.app.app_context():
             db.session.remove()

--- a/tests/logic/test_logic.py
+++ b/tests/logic/test_logic.py
@@ -90,6 +90,7 @@ class PackageTest(unittest.TestCase):
         self.assertEqual(metadata['readme'], '')
         self.assertEqual(metadata['id'], 1)
 
+
     def test_returns_none_if_package_not_found(self):
         package = get_metadata_for_package(self.publisher, 'unknown')
         self.assertIsNone(package)
@@ -144,6 +145,17 @@ class PackageTest(unittest.TestCase):
     def test_get_package_names_for_publisher_throws_404_if_no_package_found(self):
         with self.assertRaises(InvalidUsage) as context:
             get_package_names_for_publisher('not_a_publisher')
+        self.assertEqual(context.exception.status_code, 404)
+
+
+    def test_get_publisher_info(self):
+        publisher = get_publisher(self.publisher)
+        self.assertEqual(publisher['name'], self.publisher)
+
+
+    def test_get_publisher_info_throws_404_if_no_publisher_found(self):
+        with self.assertRaises(InvalidUsage) as context:
+            get_publisher('not_a_publisher')
         self.assertEqual(context.exception.status_code, 404)
 
 

--- a/tests/profile/test_controllers.py
+++ b/tests/profile/test_controllers.py
@@ -39,23 +39,12 @@ class PublisherProfileTestCase(unittest.TestCase):
             db.session.add(publisher2)
             db.session.commit()
 
-    @patch('app.profile.models.Publisher.get_publisher_info')
-    def test_throw_500_if_failed_to_get_data_for_publisher(self, info_mock):
-        info_mock.side_effect = Exception
-        url = "/api/profile/publisher/{name}".format(name=self.publisher_one)
-        response = self.client.get(url)
-        self.assertEqual(500, response.status_code)
-
-    @patch('app.profile.models.Publisher.get_publisher_info')
-    def test_throw_404_if_publisher_not_found(self, info_mock):
-        info_mock.return_value = None
+    def test_throw_404_if_publisher_not_found(self):
         url = "/api/profile/publisher/{name}".format(name='unknown')
         response = self.client.get(url)
         self.assertEqual(404, response.status_code)
 
-    @patch('app.profile.models.Publisher.get_publisher_info')
-    def test_should_return_200_if_every_thing_went_well(self, info_mock):
-        info_mock.return_value = {}
+    def test_should_return_200_if_every_thing_went_well(self):
         url = "/api/profile/publisher/{name}".format(name=self.publisher_one)
         response = self.client.get(url)
         self.assertEqual(200, response.status_code)

--- a/tests/profile/test_models.py
+++ b/tests/profile/test_models.py
@@ -31,54 +31,6 @@ class PublisherUserTestCase(unittest.TestCase):
             db.drop_all()
 
 
-class PublisherTestCase(unittest.TestCase):
-    publisher_one = 'test_publisher1'
-    publisher_two = 'test_publisher2'
-
-    def setUp(self):
-        self.app = create_app()
-        self.app.app_context().push()
-        with self.app.test_request_context():
-            db.drop_all()
-            db.create_all()
-            publisher1 = Publisher(name=self.publisher_one,
-                                   title="publisher one",
-                                   description="This is publisher one",
-                                   country="country one",
-                                   email="one@publisher.com",
-                                   phone="123",
-                                   contact_public=True)
-            publisher2 = Publisher(name=self.publisher_two,
-                                   title="publisher two",
-                                   description="This is publisher two",
-                                   country="country two",
-                                   email="two@publisher.com",
-                                   phone="321",
-                                   contact_public=False)
-            db.session.add(publisher1)
-            db.session.add(publisher2)
-            db.session.commit()
-
-    def test_should_not_return_contact_info_if_public(self):
-        info = Publisher.get_publisher_info(self.publisher_two)
-        self.assertNotIn("contact", info)
-        self.assertEqual(self.publisher_two, info['name'])
-
-    def test_should_return_contact_info_if_public(self):
-        info = Publisher.get_publisher_info(self.publisher_one)
-        self.assertIn("contact", info)
-        self.assertEqual(self.publisher_one, info['name'])
-
-    def test_should_return_None_if_publisher_not_found(self):
-        info = Publisher.get_publisher_info("not_found")
-        self.assertIsNone(info)
-
-    def tearDown(self):
-        with self.app.app_context():
-            db.session.remove()
-            db.drop_all()
-
-
 class UserTestCase(unittest.TestCase):
     def setUp(self):
         self.app = create_app()

--- a/tests/profile/test_models.py
+++ b/tests/profile/test_models.py
@@ -74,10 +74,6 @@ class UserTestCase(unittest.TestCase):
         user = User.create_or_update_user_from_callback(user_info)
         self.assertNotEqual('supersecret', user.secret)
 
-    def test_get_user_info_by_id(self):
-        self.assertEqual(User.get_userinfo_by_id(11).name, 'test_user_id')
-        self.assertIsNone(User.get_userinfo_by_id(2))
-
     def test_create_user_should_handle_null_email(self):
         user_info = dict(login="test_null_email")
         User.create_or_update_user_from_callback(user_info)

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -65,6 +65,13 @@ class SchemaTest(unittest.TestCase):
         self.assertEqual(publisher_schema.dump(publisher).data['name'], self.publisher)
 
 
+    def test_schema_for_publisher_with_pubic_contact(self):
+        publisher = Publisher(name=self.publisher, contact_public=True)
+        publisher_schema = PublisherSchema()
+        expected = {'country': None, 'email': None, 'phone': None}
+        self.assertEqual(publisher_schema.dump(publisher).data['contact'], expected)
+
+
     def test_nested_relationships(self):
 
         publisher = Publisher(name=self.publisher, id=3)


### PR DESCRIPTION
Using schema for getting publisher and user info instead of static methods

- new schema for dumping publisher info 
- getting user and publisher infos moved to logic layer.
- using marshmallow instead of static methods from models.
- tests updated appropriately
- refs #376