### PR TITLE
Publisher page fix ups

### DIFF
--- a/tests/site/test_controller.py
+++ b/tests/site/test_controller.py
@@ -49,6 +49,22 @@ class WebsiteTestCase(unittest.TestCase):
         rv = self.client.get('/logout')
         self.assertNotEqual(404, rv.status_code)
 
+    def test_publisher_page_loads_fine(self):
+        with self.app.app_context():
+            publisher = Publisher(name=self.publisher)
+            db.session.add(publisher)
+            db.session.commit()
+        rv = self.client.get('/%s' % self.publisher)
+        self.assertEqual(200, rv.status_code)
+
+    def test_publisher_page_results_404_for_non_existing_publisher(self):
+        with self.app.app_context():
+            publisher = Publisher(name=self.publisher)
+            db.session.add(publisher)
+            db.session.commit()
+        rv = self.client.get('/unknown' )
+        self.assertEqual(404, rv.status_code)
+
     def test_data_package_page(self):
         descriptor = json.loads(open('fixtures/datapackage.json').read())
         with self.app.app_context():


### PR DESCRIPTION
refs #325 

The issue mostly was fixed automatically in previous PR https://github.com/frictionlessdata/dpr-api/pull/392 when we moved from static methods to serialization and moved out logic from controllers

So this pr includes test that publisher page is loading fine if publisher exist and results 404 if not

