### PR TITLE
Refactor tagging of data package

### DIFF
--- a/app/logic/__init__.py
+++ b/app/logic/__init__.py
@@ -127,21 +127,17 @@ class Package(LogicBase):
     def create_or_update_tag(cls, publisher, package, tag):
         package = models.Package.get_by_publisher(publisher, package)
 
-        data_latest = models.PackageTag.query.join(models.Package)\
-            .filter(models.Package.id == package.id,
-                    models.PackageTag.tag == 'latest').one()
-
         tag_instance = models.PackageTag.query.join(models.Package) \
             .filter(models.Package.id == package.id,
                     models.PackageTag.tag == tag).first()
 
-        update_props = ['descriptor', 'readme', 'package_id']
         if tag_instance is None:
             tag_instance = models.PackageTag()
 
-        for update_prop in update_props:
-            setattr(tag_instance, update_prop, getattr(data_latest, update_prop))
         tag_instance.tag = tag
+        tag_instance.readme = package.readme
+        tag_instance.descriptor = package.descriptor
+        tag_instance.package_id = package.id
 
         db.session.add(tag_instance)
         db.session.commit()

--- a/app/package/models.py
+++ b/app/package/models.py
@@ -40,6 +40,9 @@ class Package(db.Model):
                              cascade="save-update, merge, delete, delete-orphan",
                              single_parent=True)
 
+    descriptor = db.Column(db.JSON)
+    readme = db.Column(db.TEXT)
+
     tags = relationship("PackageTag", back_populates="package")
 
     __table_args__ = (

--- a/tests/logic/test_classmethods.py
+++ b/tests/logic/test_classmethods.py
@@ -13,7 +13,8 @@ import app.models as models
 
 
 class PackageClassMethodsTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setup_class(self):
         self.publisher_name = 'demo'
         self.package_name = 'demo-package'
         self.app = create_app()
@@ -26,9 +27,8 @@ class PackageClassMethodsTest(unittest.TestCase):
                 'demot@test.com', self.publisher_name, 'super_secret'
             self.publisher = models.Publisher(name=self.publisher_name)
             self.association = models.PublisherUser(role=models.UserRoleEnum.owner)
-            self.metadata = models.Package(name=self.package_name)
-            self.metadata.tags.append(models.PackageTag(descriptor={}))
-            self.publisher.packages.append(self.metadata)
+            self.package = models.Package(name=self.package_name, descriptor={})
+            self.publisher.packages.append(self.package)
             self.association.publisher = self.publisher
             self.user.publishers.append(self.association)
 
@@ -51,11 +51,11 @@ class PackageClassMethodsTest(unittest.TestCase):
         self.assertIsNone(pkg)
 
 
-    def tearDown(self):
+    @classmethod
+    def teardown_class(self):
         with self.app.app_context():
             db.session.remove()
             db.drop_all()
-            db.engine.dispose()
 
 
 class PublisherClassMethodsTest(unittest.TestCase):

--- a/tests/logic/test_logic.py
+++ b/tests/logic/test_logic.py
@@ -9,7 +9,7 @@ from app.profile.models import *
 import app.logic as logic
 from app.utils import InvalidUsage
 
-def create_test_package(publisher='demo', package='demo-package', descriptor={}):
+def create_test_package(publisher='demo', package='demo-package', descriptor={}, readme=''):
 
     user = User(name=publisher)
     publisher = Publisher(name=publisher)
@@ -17,10 +17,8 @@ def create_test_package(publisher='demo', package='demo-package', descriptor={})
     association.publisher = publisher
     user.publishers.append(association)
 
-    metadata = Package(name=package)
-    tag = PackageTag(descriptor=descriptor)
-    metadata.tags.append(tag)
-    publisher.packages.append(metadata)
+    package = Package(name=package, descriptor=descriptor, readme=readme)
+    publisher.packages.append(package)
 
     db.session.add(user)
     db.session.commit()
@@ -28,7 +26,8 @@ def create_test_package(publisher='demo', package='demo-package', descriptor={})
 
 class DataPackageShowTest(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setup_class(self):
         self.publisher = 'demo'
         self.package = 'demo-package'
         self.app = create_app()
@@ -56,12 +55,12 @@ class DataPackageShowTest(unittest.TestCase):
         package = logic.Package.get('unknown', 'unknown')
         self.assertIsNone(package)
 
-    def tearDown(self):
+    @classmethod
+    def teardown_class(self):
         with self.app.app_context():
             db.session.remove()
             db.drop_all()
             db.engine.dispose()
-
 
 class PackageTest(unittest.TestCase):
 

--- a/tests/package/test_controller.py
+++ b/tests/package/test_controller.py
@@ -38,9 +38,8 @@ class GetMetaDataTestCase(unittest.TestCase):
         descriptor = {'name': 'test description'}
         with self.app.app_context():
             publisher = Publisher(name=self.publisher)
-            metadata = Package(name=self.package)
-            metadata.tags.append(PackageTag(descriptor=descriptor))
-            publisher.packages.append(metadata)
+            package = Package(name=self.package, descriptor=descriptor)
+            publisher.packages.append(package)
             db.session.add(publisher)
             db.session.commit()
         response = self.client.\
@@ -53,10 +52,9 @@ class GetMetaDataTestCase(unittest.TestCase):
         readme = 'README'
         with self.app.app_context():
             publisher = Publisher(name=self.publisher)
-            metadata = Package(name=self.package)
-            metadata.tags.append(PackageTag(descriptor=descriptor,
-                                            readme=readme))
-            publisher.packages.append(metadata)
+            package = Package(name=self.package,descriptor=descriptor,
+                                            readme=readme)
+            publisher.packages.append(package)
             db.session.add(publisher)
             db.session.commit()
         response = self.client.get('/api/package/%s/%s'%\

--- a/tests/package/test_models.py
+++ b/tests/package/test_models.py
@@ -21,8 +21,8 @@ class PackageTestCase(unittest.TestCase):
         self.publisher_one = 'test_publisher1'
         self.publisher_two = 'test_publisher2'
         self.package_one = 'test_package1'
-        self.package_two = 'test_package2'
-        self.package_three = 'test_package3'
+        self.readme = 'README'
+        self.descriptor = dict(name='test')
         self.app = create_app()
         self.app.app_context().push()
 
@@ -42,14 +42,27 @@ class PackageTestCase(unittest.TestCase):
             association2.publisher = publisher2
             user2.publishers.append(association2)
 
-            metadata1 = Package(name=self.package_one)
-            tag1 = PackageTag(descriptor=dict(name='test_one'))
-            metadata1.tags.append(tag1)
-            publisher1.packages.append(metadata1)
+
+
+            metadata = Package(
+                name=self.package_one,
+                descriptor=self.descriptor,
+                readme=self.readme
+            )
+            publisher1.packages.append(metadata)
 
             db.session.add(user1)
             db.session.add(user2)
             db.session.commit()
+
+    def test_package_table_has_readme_and_descriptor(self):
+        pkg = Package.get_by_publisher(self.publisher_one, self.package_one)
+        self.assertEqual(pkg.readme, self.readme)
+        self.assertEqual(pkg.descriptor, self.descriptor)
+
+    def test_tags_column_is_empty_when_created(self):
+        pkg = Package.get_by_publisher(self.publisher_one, self.package_one)
+        self.assertEqual(pkg.tags, [])
 
     def test_composite_key(self):
         res = Package.query.join(Publisher).filter(Publisher.name ==

--- a/tests/site/test_controller.py
+++ b/tests/site/test_controller.py
@@ -36,9 +36,8 @@ class WebsiteTestCase(unittest.TestCase):
         descriptor = json.loads(open('fixtures/datapackage.json').read())
         with self.app.app_context():
             publisher = Publisher(name='core')
-            metadata = Package(name='gold-prices')
-            metadata.tags.append(PackageTag(descriptor=descriptor))
-            publisher.packages.append(metadata)
+            package = Package(name='gold-prices', descriptor=descriptor)
+            publisher.packages.append(package)
             db.session.add(publisher)
             db.session.commit()
         rv = self.client.get('/')
@@ -69,9 +68,8 @@ class WebsiteTestCase(unittest.TestCase):
         descriptor = json.loads(open('fixtures/datapackage.json').read())
         with self.app.app_context():
             publisher = Publisher(name=self.publisher)
-            metadata = Package(name=self.package)
-            metadata.tags.append(PackageTag(descriptor=descriptor))
-            publisher.packages.append(metadata)
+            package = Package(name=self.package, descriptor=descriptor)
+            publisher.packages.append(package)
             db.session.add(publisher)
             db.session.commit()
         rv = self.client.get('/{publisher}/{package}'.\
@@ -89,9 +87,8 @@ class WebsiteTestCase(unittest.TestCase):
         descriptor['licenses'] = {'url': 'test/url', 'type': 'Test'}
         with self.app.app_context():
             publisher = Publisher(name=self.publisher)
-            metadata = Package(name=self.package)
-            metadata.tags.append(PackageTag(descriptor=descriptor))
-            publisher.packages.append(metadata)
+            package = Package(name=self.package, descriptor=descriptor)
+            publisher.packages.append(package)
             db.session.add(publisher)
             db.session.commit()
         rv = self.client.get('/%s/%s' %(self.publisher,self.package))
@@ -102,9 +99,8 @@ class WebsiteTestCase(unittest.TestCase):
         descriptor = {"data": [], "resources": []}
         with self.app.app_context():
             publisher = Publisher(name=self.publisher)
-            metadata = Package(name=self.package)
-            metadata.tags.append(PackageTag(descriptor=descriptor))
-            publisher.packages.append(metadata)
+            package = Package(name=self.package, descriptor=descriptor)
+            publisher.packages.append(package)
             db.session.add(publisher)
             db.session.commit()
         rv = self.client.get('/{publisher}/{package}'.\
@@ -234,10 +230,9 @@ class DataPackageShowTest(unittest.TestCase):
             descriptor = json.loads(open('fixtures/datapackage.json').read())
             readme = open('fixtures/README.md').read()
             publisher = Publisher(name=self.publisher)
-            metadata = Package(name=self.package)
-            metadata.tags.append(PackageTag(descriptor=descriptor, readme=readme))
+            package = Package(name=self.package,descriptor=descriptor, readme=readme)
 
-            publisher.packages.append(metadata)
+            publisher.packages.append(package)
             db.session.add(publisher)
             db.session.commit()
 


### PR DESCRIPTION
- Package table refactored to have it's own descriptor and README
- logic refactored to insert descriptor and readme into package table when publishing
- tests refactored appropriately  + new tests
- creation of tag refactored to be done explicitly 

